### PR TITLE
Fix CopyWebpackPlugin

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,18 +13,22 @@ module.exports = {
           GA_TRACKING_CODE: JSON.stringify(process.env.GA_TRACKING_CODE),
           CECIUM_ACCESS_TOKEN: JSON.stringify(process.env.CECIUM_ACCESS_TOKEN),
         },
-      }),
-      isProduction
-        ? new CopyWebpackPlugin({
-            patterns: [
-              {
-                from: 'node_modules/cesium/Build/Cesium',
-                to: '../public/cesium',
-              },
-            ],
-          })
-        : {}
+      })
     );
+
+    if (isProduction) {
+      config.plugins.push(
+        new CopyWebpackPlugin({
+          patterns: [
+            {
+              from: 'node_modules/cesium/Build/Cesium',
+              to: '../public/cesium',
+            },
+          ],
+        })
+      );
+    }
+
     return config;
-  }
+  },
 };


### PR DESCRIPTION
# What
- Starting server in development was failed.
- Empty object(`{}`) in `config.plugins` cause this error, so I fixed  it.

# Error

```
npm run dev 

> satelite_tracker@2.0.0 dev
> next dev

ready - started server on 0.0.0.0:3000, url: http://localhost:3000
info  - Using webpack 5. Reason: Enabled by default https://nextjs.org/docs/messages/webpack5
ValidationError: Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration[0].plugins[13] misses the property 'apply'. Should be:
   function
   -> The run point of the plugin, required method.
 - configuration[1].plugins[8] misses the property 'apply'. Should be:
   function
```